### PR TITLE
Fix property visibility

### DIFF
--- a/src/app/person/person.component.ts
+++ b/src/app/person/person.component.ts
@@ -7,7 +7,7 @@ import { PEOPLE } from '../_static/people';
     styleUrls: ['person.component.css']
 })
 export class PersonComponent implements OnInit {    
-    private person: any;
+    public person: any;
     
     constructor() {
         this.person = PEOPLE[0];


### PR DESCRIPTION
Set PersonComponent.person property to public (used in template)
So `ng-lint` doesn't print a warning.